### PR TITLE
Add clients page and enhance agenda

### DIFF
--- a/backend/src/routes/clientes.ts
+++ b/backend/src/routes/clientes.ts
@@ -1,0 +1,49 @@
+import { Router, Request, Response } from "express";
+import { pool } from "../db";
+import autenticar from "../middlewares/autenticar";
+
+const router = Router();
+
+// Lista clientes do representante com potenciais e valores por grupo
+router.get("/", autenticar, async (req: Request, res: Response) => {
+    const codusuario = (req as any).user?.codusuario;
+    try {
+        const { rows } = await pool.query(
+            `SELECT c.id_cliente, c.nome AS nome_cliente, g.id_grupo, g.nome AS nome_grupo,
+                    cg.potencial_compra, cg.valor_comprado
+             FROM agr_clientes c
+             LEFT JOIN agr_cliente_grupo cg ON c.id_cliente = cg.id_cliente
+             LEFT JOIN agr_grupos g ON cg.id_grupo = g.id_grupo
+             WHERE c.cod_representante = $1
+             ORDER BY c.nome, g.id_grupo`,
+            [codusuario]
+        );
+        res.json(rows);
+    } catch (err) {
+        console.error("Erro ao listar clientes:", err);
+        res.status(500).json({ erro: "Erro ao listar clientes" });
+    }
+});
+
+// Atualiza potencial de compra de um cliente em um grupo
+router.put(
+    "/:id_cliente/grupos/:id_grupo",
+    autenticar,
+    async (req: Request, res: Response) => {
+        const { id_cliente, id_grupo } = req.params;
+        const { potencial_compra } = req.body;
+        try {
+            await pool.query(
+                `UPDATE agr_cliente_grupo SET potencial_compra = $1
+                 WHERE id_cliente = $2 AND id_grupo = $3`,
+                [potencial_compra, id_cliente, id_grupo]
+            );
+            res.sendStatus(200);
+        } catch (err) {
+            console.error("Erro ao atualizar potencial:", err);
+            res.status(500).json({ erro: "Erro ao atualizar potencial" });
+        }
+    }
+);
+
+export default router;

--- a/backend/src/routes/visitas.ts
+++ b/backend/src/routes/visitas.ts
@@ -56,6 +56,19 @@ router.put("/:id/confirmar", autenticar, async (req: Request, res: Response) => 
     }
 });
 
+// Atualizar observação de uma visita
+router.put("/:id/observacao", autenticar, async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const { observacao } = req.body;
+    try {
+        await pool.query("UPDATE agr_visitas SET observacao = $1 WHERE id = $2", [observacao, id]);
+        res.sendStatus(200);
+    } catch (err) {
+        console.error("Erro ao atualizar observação:", err);
+        res.status(500).json({ erro: "Erro ao atualizar observação" });
+    }
+});
+
 // Listar clientes por representante
 router.get("/clientes/representante", autenticar, async (req: Request, res: Response) => {
     const codusuario = (req as any).user?.codusuario;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import cors from "cors"
 import dotenv from "dotenv"
 import authRoutes from "./routes/auth"
 import visitasRoutes from "./routes/visitas"
+import clientesRoutes from "./routes/clientes"
 
 dotenv.config()
 
@@ -15,6 +16,7 @@ app.use(express.json())
 
 app.use("/auth", authRoutes)
 app.use("/visitas", visitasRoutes)
+app.use("/clientes", clientesRoutes)
 
 app.listen(PORT, () => {
   console.log(`Servidor rodando na porta ${PORT}`)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Layout from "./components/Layout";
 import Agenda from "./pages/Agenda";
+import Clientes from "./pages/Clientes";
 
 function App() {
   const token = localStorage.getItem("token");
@@ -22,7 +23,7 @@ function App() {
         />
         <Route
           path="/clientes"
-          element={token ? <Layout><div>Clientes</div></Layout> : <Navigate to="/" />}
+          element={token ? <Layout><Clientes /></Layout> : <Navigate to="/" />}
         />
         <Route
           path="/potenciais"

--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -1,0 +1,86 @@
+import { Box, Typography, Table, TableBody, TableCell, TableHead, TableRow, TextField, LinearProgress, Button, Paper } from "@mui/material";
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+interface LinhaCliente {
+    id_cliente: string;
+    nome_cliente: string;
+    id_grupo: string;
+    nome_grupo: string;
+    potencial_compra: number;
+    valor_comprado: number;
+}
+
+export default function Clientes() {
+    const [dados, setDados] = useState<LinhaCliente[]>([]);
+    const token = localStorage.getItem("token");
+
+    const carregar = async () => {
+        const res = await axios.get("http://localhost:8501/clientes", {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        setDados(res.data);
+    };
+
+    useEffect(() => {
+        carregar();
+    }, []);
+
+    const handleChange = (index: number, valor: string) => {
+        const novo = [...dados];
+        novo[index].potencial_compra = Number(valor);
+        setDados(novo);
+    };
+
+    const salvar = async (linha: LinhaCliente) => {
+        await axios.put(
+            `http://localhost:8501/clientes/${linha.id_cliente}/grupos/${linha.id_grupo}`,
+            { potencial_compra: linha.potencial_compra },
+            { headers: { Authorization: `Bearer ${token}` } }
+        );
+        carregar();
+    };
+
+    return (
+        <Box>
+            <Typography variant="h5" gutterBottom>Clientes</Typography>
+            <Paper>
+                <Table size="small">
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>Cliente</TableCell>
+                            <TableCell>Grupo</TableCell>
+                            <TableCell align="right">Comprado</TableCell>
+                            <TableCell align="right">Potencial</TableCell>
+                            <TableCell width="150">Progresso</TableCell>
+                            <TableCell></TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {dados.map((linha, idx) => (
+                            <TableRow key={`${linha.id_cliente}-${linha.id_grupo}`}>
+                                <TableCell>{linha.nome_cliente}</TableCell>
+                                <TableCell>{linha.nome_grupo}</TableCell>
+                                <TableCell align="right">{linha.valor_comprado}</TableCell>
+                                <TableCell align="right">
+                                    <TextField
+                                        size="small"
+                                        type="number"
+                                        value={linha.potencial_compra}
+                                        onChange={(e) => handleChange(idx, e.target.value)}
+                                    />
+                                </TableCell>
+                                <TableCell>
+                                    <LinearProgress variant="determinate" value={linha.potencial_compra ? (linha.valor_comprado / linha.potencial_compra) * 100 : 0} />
+                                </TableCell>
+                                <TableCell>
+                                    <Button size="small" variant="contained" onClick={() => salvar(linha)}>Salvar</Button>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </Paper>
+        </Box>
+    );
+}


### PR DESCRIPTION
## Summary
- show scheduled visits with option to confirm and edit observation
- fix client selection when scheduling
- expose endpoint to update visit observation
- add API for client potential management
- add clients page with progress bars

## Testing
- `npm run build` *(fails: Missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68516b8236808324b7feb167fbf22dbd