### PR TITLE
Improve clients list and agenda UI

### DIFF
--- a/frontend/src/pages/Agenda.tsx
+++ b/frontend/src/pages/Agenda.tsx
@@ -140,7 +140,7 @@ const Agenda = () => {
                                                 <Typography variant="body2" fontSize={12}>{visita.observacao}</Typography>
                                             )}
                                             {!visita.confirmado && editarObservacaoId !== visita.id && (
-                                                <IconButton size="small" onClick={() => confirmarVisita(visita)}>
+                                                <IconButton size="small" onClick={() => confirmarVisita(visita)} sx={{ position: "absolute", bottom: 2, right: 2 }}>
                                                     <Check fontSize="small" />
                                                 </IconButton>
                                             )}


### PR DESCRIPTION
## Summary
- add expandable client rows with pagination
- keep confirm button inside agenda cell

## Testing
- `npm --prefix frontend run build` *(fails: Cannot find modules)*
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68516f0484a883249ac0d13badba0a3d