### PR TITLE
Fix cliente totals and add dashboard metrics

### DIFF
--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -36,7 +36,12 @@ export default function Clientes() {
         const res = await axios.get("http://localhost:8501/clientes", {
             headers: { Authorization: `Bearer ${token}` },
         });
-        setDados(res.data);
+        const convertidos = res.data.map((linha: any) => ({
+            ...linha,
+            potencial_compra: Number(linha.potencial_compra),
+            valor_comprado: Number(linha.valor_comprado),
+        }));
+        setDados(convertidos);
     };
 
     useEffect(() => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,44 @@
 import { Box, Paper, Typography } from "@mui/material";
+import axios from "axios";
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
 
 export default function Dashboard() {
+    const [clientes, setClientes] = useState<any[]>([]);
+    const [visitas, setVisitas] = useState<any[]>([]);
+    const [potencialTotal, setPotencialTotal] = useState(0);
+    const token = localStorage.getItem("token");
+
+    const carregar = async () => {
+        const resClientes = await axios.get("http://localhost:8501/clientes", {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        const dadosClientes = resClientes.data.map((l: any) => ({
+            ...l,
+            potencial_compra: Number(l.potencial_compra),
+        }));
+        setClientes(dadosClientes);
+        setPotencialTotal(
+            dadosClientes.reduce((s: number, c: any) => s + c.potencial_compra, 0)
+        );
+
+        const inicio = dayjs().startOf("week").format("YYYY-MM-DD");
+        const fim = dayjs().endOf("week").format("YYYY-MM-DD");
+        const resVisitas = await axios.get("http://localhost:8501/visitas", {
+            params: { inicio, fim },
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        setVisitas(resVisitas.data);
+    };
+
+    useEffect(() => {
+        carregar();
+    }, []);
+
+    const qtdClientes = Array.from(
+        new Set(clientes.map((c: any) => c.id_cliente))
+    ).length;
+
     return (
         <Box>
             <Typography variant="h4" gutterBottom>
@@ -10,17 +48,17 @@ export default function Dashboard() {
             <Box display="flex" flexDirection={{ xs: 'column', md: 'row' }} gap={3}>
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>
                     <Typography variant="h6">Clientes Ativos</Typography>
-                    <Typography variant="h4" color="primary">--</Typography>
+                    <Typography variant="h4" color="primary">{qtdClientes}</Typography>
                 </Paper>
 
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>
                     <Typography variant="h6">Visitas na Semana</Typography>
-                    <Typography variant="h4" color="primary">--</Typography>
+                    <Typography variant="h4" color="primary">{visitas.length}</Typography>
                 </Paper>
 
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>
                     <Typography variant="h6">Potencial Total de Compra</Typography>
-                    <Typography variant="h4" color="primary">--</Typography>
+                    <Typography variant="h4" color="primary">{potencialTotal.toFixed(2)}</Typography>
                 </Paper>
             </Box>
 


### PR DESCRIPTION
## Summary
- convert numeric fields from API response in Clientes page
- fetch dashboard metrics and display counts

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685192fee9308324b6d46a687a7aa610