### PR TITLE
Improve dashboard and clients layout

### DIFF
--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -1,5 +1,25 @@
-import { Box, Typography, Table, TableBody, TableCell, TableHead, TableRow, TextField, LinearProgress, Button, Paper, Collapse, IconButton, TablePagination } from "@mui/material";
-import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
+import {
+    Box,
+    Typography,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+    TextField,
+    LinearProgress,
+    Button,
+    Paper,
+    Collapse,
+    IconButton,
+    TablePagination,
+} from "@mui/material";
+import {
+    KeyboardArrowDown,
+    KeyboardArrowUp,
+    ShoppingCart,
+    MonetizationOn,
+} from "@mui/icons-material";
 import axios from "axios";
 import { useEffect, useState } from "react";
 
@@ -13,6 +33,12 @@ const formatarTelefone = (tel: string) => {
     }
     return tel;
 };
+
+const formatarMoeda = (valor: number) =>
+    valor.toLocaleString("pt-BR", {
+        style: "currency",
+        currency: "BRL",
+    });
 
 interface LinhaCliente {
     id_cliente: string;
@@ -113,8 +139,14 @@ export default function Clientes() {
                             <TableCell width="50"></TableCell>
                             <TableCell>Cliente</TableCell>
                             <TableCell>Telefone</TableCell>
-                            <TableCell align="right">Comprado</TableCell>
-                            <TableCell align="right">Potencial</TableCell>
+                            <TableCell align="right">
+                                <ShoppingCart fontSize="small" sx={{ mr: 0.5 }} />
+                                Comprado
+                            </TableCell>
+                            <TableCell align="right">
+                                <MonetizationOn fontSize="small" sx={{ mr: 0.5 }} />
+                                Potencial
+                            </TableCell>
                             <TableCell width="150">Progresso</TableCell>
                         </TableRow>
                     </TableHead>
@@ -129,8 +161,14 @@ export default function Clientes() {
                                     </TableCell>
                                     <TableCell>{c.nome}</TableCell>
                                     <TableCell>{c.telefone}</TableCell>
-                                    <TableCell align="right">{c.totalComprado.toFixed(2)}</TableCell>
-                                    <TableCell align="right">{c.totalPotencial.toFixed(2)}</TableCell>
+                                    <TableCell align="right">
+                                        <ShoppingCart fontSize="small" sx={{ mr: 0.5 }} />
+                                        {formatarMoeda(c.totalComprado)}
+                                    </TableCell>
+                                    <TableCell align="right">
+                                        <MonetizationOn fontSize="small" sx={{ mr: 0.5 }} />
+                                        {formatarMoeda(c.totalPotencial)}
+                                    </TableCell>
                                     <TableCell>
                                         <LinearProgress variant="determinate" value={c.totalPotencial ? (c.totalComprado / c.totalPotencial) * 100 : 0} />
                                     </TableCell>
@@ -142,8 +180,14 @@ export default function Clientes() {
                                                 <TableHead>
                                                     <TableRow>
                                                         <TableCell>Grupo</TableCell>
-                                                        <TableCell align="right">Comprado</TableCell>
-                                                        <TableCell align="right">Potencial</TableCell>
+                                                        <TableCell align="right">
+                                                            <ShoppingCart fontSize="small" sx={{ mr: 0.5 }} />
+                                                            Comprado
+                                                        </TableCell>
+                                                        <TableCell align="right">
+                                                            <MonetizationOn fontSize="small" sx={{ mr: 0.5 }} />
+                                                            Potencial
+                                                        </TableCell>
                                                         <TableCell width="150">Progresso</TableCell>
                                                         <TableCell></TableCell>
                                                     </TableRow>
@@ -152,14 +196,20 @@ export default function Clientes() {
                                                     {c.grupos.map((linha: any) => (
                                                         <TableRow key={`${linha.id_cliente}-${linha.id_grupo}`}>
                                                             <TableCell>{linha.nome_grupo}</TableCell>
-                                                            <TableCell align="right">{linha.valor_comprado}</TableCell>
                                                             <TableCell align="right">
-                                                                <TextField
-                                                                    size="small"
-                                                                    type="number"
-                                                                    value={linha.potencial_compra}
-                                                                    onChange={(e) => handleChange(linha.index, e.target.value)}
-                                                                />
+                                                                <ShoppingCart fontSize="small" sx={{ mr: 0.5 }} />
+                                                                {formatarMoeda(linha.valor_comprado)}
+                                                            </TableCell>
+                                                            <TableCell align="right">
+                                                                <Box display="flex" alignItems="center">
+                                                                    <MonetizationOn fontSize="small" sx={{ mr: 0.5 }} />
+                                                                    <TextField
+                                                                        size="small"
+                                                                        type="number"
+                                                                        value={linha.potencial_compra}
+                                                                        onChange={(e) => handleChange(linha.index, e.target.value)}
+                                                                    />
+                                                                </Box>
                                                             </TableCell>
                                                             <TableCell>
                                                                 <LinearProgress variant="determinate" value={linha.potencial_compra ? (linha.valor_comprado / linha.potencial_compra) * 100 : 0} />

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { Box, Paper, Typography } from "@mui/material";
+import { People, CalendarMonth, MonetizationOn } from "@mui/icons-material";
 import axios from "axios";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
@@ -39,33 +40,56 @@ export default function Dashboard() {
         new Set(clientes.map((c: any) => c.id_cliente))
     ).length;
 
+    const formatarMoeda = (valor: number) =>
+        valor.toLocaleString("pt-BR", {
+            style: "currency",
+            currency: "BRL",
+        });
+
+    const atividades = [
+        "Visita confirmada com Innovatech Solutions em 28/07/2024",
+        "Visita agendada com New Lead Co. em 30/07/2024",
+    ];
+
     return (
         <Box>
-            <Typography variant="h4" gutterBottom>
+            <Typography variant="h5" gutterBottom>
                 Painel Geral
             </Typography>
 
-            <Box display="flex" flexDirection={{ xs: 'column', md: 'row' }} gap={3}>
+            <Box display="flex" flexDirection={{ xs: "column", md: "row" }} gap={3}>
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>
-                    <Typography variant="h6">Clientes Ativos</Typography>
+                    <Box display="flex" alignItems="center" gap={1}>
+                        <People />
+                        <Typography variant="h6">Clientes Ativos</Typography>
+                    </Box>
                     <Typography variant="h4" color="primary">{qtdClientes}</Typography>
                 </Paper>
 
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>
-                    <Typography variant="h6">Visitas na Semana</Typography>
+                    <Box display="flex" alignItems="center" gap={1}>
+                        <CalendarMonth />
+                        <Typography variant="h6">Visitas na Semana</Typography>
+                    </Box>
                     <Typography variant="h4" color="primary">{visitas.length}</Typography>
                 </Paper>
 
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>
-                    <Typography variant="h6">Potencial Total de Compra</Typography>
-                    <Typography variant="h4" color="primary">{potencialTotal.toFixed(2)}</Typography>
+                    <Box display="flex" alignItems="center" gap={1}>
+                        <MonetizationOn />
+                        <Typography variant="h6">Potencial Total de Compra</Typography>
+                    </Box>
+                    <Typography variant="h4" color="primary">{formatarMoeda(potencialTotal)}</Typography>
                 </Paper>
             </Box>
 
             <Box mt={4}>
-                <Typography variant="body1" color="textSecondary">
-                    Em breve: sugestões de visitas, agenda e relatórios.
-                </Typography>
+                <Typography variant="h6" gutterBottom>Atividade Recente</Typography>
+                <Paper sx={{ p: 2 }}>
+                    {atividades.map((a) => (
+                        <Typography key={a}>{a}</Typography>
+                    ))}
+                </Paper>
             </Box>
         </Box>
     );


### PR DESCRIPTION
## Summary
- style Dashboard page with icons and currency formatting
- show recent activity list on Dashboard
- add Brazilian currency formatting and icons in Clientes page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851983391e48324b48aff9e24f8f0b0