### PR TITLE
Integrate recent visits into Dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -46,10 +46,18 @@ export default function Dashboard() {
             currency: "BRL",
         });
 
-    const atividades = [
-        "Visita confirmada com Innovatech Solutions em 28/07/2024",
-        "Visita agendada com New Lead Co. em 30/07/2024",
-    ];
+    const atividades = visitas
+        .slice()
+        .sort((a, b) =>
+            dayjs(`${b.data} ${b.hora}`).diff(dayjs(`${a.data} ${a.hora}`))
+        )
+        .map((v) => {
+            const nome = v.nome_cliente || v.nome_cliente_temp;
+            const dataFormatada = dayjs(v.data).format("DD/MM/YYYY");
+            return v.confirmado
+                ? `Visita confirmada com ${nome} em ${dataFormatada}`
+                : `Visita agendada com ${nome} em ${dataFormatada}`;
+        });
 
     return (
         <Box>


### PR DESCRIPTION
## Summary
- compute recent activity from weekly visits

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module '@mui/icons-material', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68519debb16883248eadabde94e5642f