### PR TITLE
Add manager-level filters

### DIFF
--- a/backend/src/routes/clientes.ts
+++ b/backend/src/routes/clientes.ts
@@ -6,7 +6,10 @@ const router = Router();
 
 // Lista clientes do representante com potenciais e valores por grupo
 router.get("/", autenticar, async (req: Request, res: Response) => {
-    const codusuario = (req as any).user?.codusuario;
+    const { codusuario: codParam } = req.query as any;
+    const { codusuario, perfil } = (req as any).user || {};
+    const representante = (perfil === "coordenador" || perfil === "diretor") && codParam ? codParam : codusuario;
+
     try {
         const { rows } = await pool.query(
             `SELECT c.id_cliente, c.nome AS nome_cliente, c.telefone, g.id_grupo, g.nome AS nome_grupo,
@@ -16,7 +19,7 @@ router.get("/", autenticar, async (req: Request, res: Response) => {
              LEFT JOIN agr_grupos g ON cg.id_grupo = g.id_grupo
              WHERE c.cod_representante = $1
              ORDER BY c.nome, g.id_grupo`,
-            [codusuario]
+            [representante]
         );
         res.json(rows);
     } catch (err) {

--- a/backend/src/routes/usuarios.ts
+++ b/backend/src/routes/usuarios.ts
@@ -1,0 +1,35 @@
+import { Router, Request, Response } from "express";
+import { pool } from "../db";
+import autenticar from "../middlewares/autenticar";
+
+const router = Router();
+
+router.get("/representantes", autenticar, async (req: Request, res: Response) => {
+    const { codusuario, perfil } = (req as any).user || {};
+
+    if (!perfil) {
+        return res.status(401).json({ erro: "Usuário não autenticado" });
+    }
+
+    try {
+        let query = "";
+        let params: any[] = [];
+
+        if (perfil === "coordenador") {
+            query = "SELECT codusuario, nome FROM agr_usuarios WHERE perfil = 'representante' AND coordenador_id = $1 ORDER BY nome";
+            params = [codusuario];
+        } else if (perfil === "diretor") {
+            query = "SELECT codusuario, nome FROM agr_usuarios WHERE perfil = 'representante' ORDER BY nome";
+        } else {
+            return res.status(403).json({ erro: "Sem permissão" });
+        }
+
+        const { rows } = await pool.query(query, params);
+        res.json(rows);
+    } catch (err) {
+        console.error("Erro ao listar representantes:", err);
+        res.status(500).json({ erro: "Erro ao listar representantes" });
+    }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv"
 import authRoutes from "./routes/auth"
 import visitasRoutes from "./routes/visitas"
 import clientesRoutes from "./routes/clientes"
+import usuariosRoutes from "./routes/usuarios"
 
 dotenv.config()
 
@@ -17,6 +18,7 @@ app.use(express.json())
 app.use("/auth", authRoutes)
 app.use("/visitas", visitasRoutes)
 app.use("/clientes", clientesRoutes)
+app.use("/usuarios", usuariosRoutes)
 
 app.listen(PORT, () => {
   console.log(`Servidor rodando na porta ${PORT}`)


### PR DESCRIPTION
## Summary
- support listing representatives with new `/usuarios/representantes` route
- allow coordinators and directors to filter visits and clients by representative
- display representative filter and appointment counts in Agenda page

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851ab424cf483249f3ecefc7ddf741a