### PR TITLE
Improve layout for Agenda and Clientes

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Container } from "@mui/material";
 import Sidebar from "../components/Sidebar";
 import type { ReactNode } from "react";
 
@@ -11,7 +11,7 @@ export default function Layout({ children }: LayoutProps) {
         <Box display="flex" minHeight="100vh">
             <Sidebar />
             <Box component="main" flexGrow={1} p={3} bgcolor="#f5f6fa">
-                {children}
+                <Container maxWidth="lg">{children}</Container>
             </Box>
         </Box>
     );

--- a/frontend/src/pages/Agenda.tsx
+++ b/frontend/src/pages/Agenda.tsx
@@ -122,22 +122,34 @@ const Agenda = () => {
 
     return (
         <Box p={2}>
-            {(perfil === "coordenador" || perfil === "diretor") && (
-                <Box mb={2}>
+            <Box
+                display="flex"
+                justifyContent="space-between"
+                alignItems="center"
+                flexWrap="wrap"
+                mb={2}
+            >
+                <Typography variant="h5" gutterBottom>
+                    Agenda Semanal
+                </Typography>
+                {(perfil === "coordenador" || perfil === "diretor") && (
                     <TextField
                         select
                         label="Representante"
                         value={repSelecionado}
                         onChange={(e) => setRepSelecionado(e.target.value)}
                         size="small"
+                        sx={{ minWidth: 200, mt: { xs: 1, sm: 0 } }}
                     >
                         <MenuItem value="">Todos</MenuItem>
                         {representantes.map((r: any) => (
-                            <MenuItem key={r.codusuario} value={r.codusuario}>{r.nome}</MenuItem>
+                            <MenuItem key={r.codusuario} value={r.codusuario}>
+                                {r.nome}
+                            </MenuItem>
                         ))}
                     </TextField>
-                </Box>
-            )}
+                )}
+            </Box>
             <Box display="flex" justifyContent="space-between" mb={2}>
                 <Button onClick={() => setSemanaAtual(semanaAtual.subtract(1, "week"))}>Semana anterior</Button>
                 <Typography variant="h6">Semana de {diasSemana[0].format("DD/MM")} a {diasSemana[6].format("DD/MM")}</Typography>

--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -174,15 +174,24 @@ export default function Clientes() {
 
     return (
         <Box>
-            <Typography variant="h5" gutterBottom>Clientes</Typography>
-            {(perfil === "coordenador" || perfil === "diretor") && (
-                <Box mb={1}>
+            <Box
+                display="flex"
+                justifyContent="space-between"
+                alignItems="center"
+                flexWrap="wrap"
+                mb={2}
+            >
+                <Typography variant="h5" gutterBottom sx={{ mr: 2 }}>
+                    Clientes
+                </Typography>
+                {(perfil === "coordenador" || perfil === "diretor") && (
                     <TextField
                         select
                         label="Representante"
                         value={repSelecionado}
                         onChange={(e) => setRepSelecionado(e.target.value)}
                         size="small"
+                        sx={{ minWidth: 200, mt: { xs: 1, sm: 0 } }}
                     >
                         <MenuItem value="">Todos</MenuItem>
                         {representantes.map((r: any) => (
@@ -191,8 +200,8 @@ export default function Clientes() {
                             </MenuItem>
                         ))}
                     </TextField>
-                </Box>
-            )}
+                )}
+            </Box>
             <TextField
                 size="small"
                 placeholder="Buscar por nome ou telefone"


### PR DESCRIPTION
## Summary
- use Container layout for consistent width
- align representative filter beside page titles
- tweak Agenda title row

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- `npm run build` *(fails: cannot find module 'dayjs' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851ba510ae48324a6868ba3c21b6310