### PR TITLE
Fix client search with missing phone

### DIFF
--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -27,7 +27,8 @@ import { useEffect, useState } from "react";
 import { jwtDecode } from "jwt-decode";
 import MenuItem from "@mui/material/MenuItem";
 
-const formatarTelefone = (tel: string) => {
+const formatarTelefone = (tel: string | null | undefined) => {
+    if (!tel) return "";
     const numeros = tel.replace(/\D/g, "");
     if (numeros.length === 11) {
         return numeros.replace(/(\d{2})(\d{5})(\d{4})/, "($1) $2-$3");
@@ -67,7 +68,7 @@ const LinearProgressWithLabel = ({ value }: { value: number }) => (
 interface LinhaCliente {
     id_cliente: string;
     nome_cliente: string;
-    telefone: string;
+    telefone: string | null;
     id_grupo: string;
     nome_grupo: string;
     potencial_compra: number;


### PR DESCRIPTION
## Summary
- handle `null` phone numbers when formatting client phone
- allow `telefone` to be `null`

## Testing
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p frontend/tsconfig.json`
- `npx tsc -p backend/tsconfig.json` *(fails: Cannot find module 'pg' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851c028f93c8324908373f5859c5939