### PR TITLE
Improve dashboard filter layout

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -90,17 +90,24 @@ export default function Dashboard() {
 
     return (
         <Box>
-            <Typography variant="h5" gutterBottom>
-                Painel Geral
-            </Typography>
-            {(perfil === "coordenador" || perfil === "diretor") && (
-                <Box mb={2}>
+            <Box
+                display="flex"
+                justifyContent="space-between"
+                alignItems="center"
+                flexWrap="wrap"
+                mb={2}
+            >
+                <Typography variant="h5" gutterBottom sx={{ mr: 2 }}>
+                    Painel Geral
+                </Typography>
+                {(perfil === "coordenador" || perfil === "diretor") && (
                     <TextField
                         select
                         label="Representante"
                         value={repSelecionado}
                         onChange={(e) => setRepSelecionado(e.target.value)}
                         size="small"
+                        sx={{ minWidth: 200, mt: { xs: 1, sm: 0 } }}
                     >
                         <MenuItem value="">Todos</MenuItem>
                         {representantes.map((r: any) => (
@@ -109,8 +116,8 @@ export default function Dashboard() {
                             </MenuItem>
                         ))}
                     </TextField>
-                </Box>
-            )}
+                )}
+            </Box>
 
             <Box display="flex" flexDirection={{ xs: "column", md: "row" }} gap={3}>
                 <Paper elevation={3} sx={{ p: 2, flex: 1 }}>


### PR DESCRIPTION
## Summary
- align dashboard filter with title using same layout as other pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851c19646748324963eba92a2602394