### PR TITLE
Use env API URL in frontend and widen layout

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8501

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,7 +11,7 @@ export default function Layout({ children }: LayoutProps) {
         <Box display="flex" minHeight="100vh">
             <Sidebar />
             <Box component="main" flexGrow={1} p={3} bgcolor="#f5f6fa">
-                <Container maxWidth="lg">{children}</Container>
+                <Container maxWidth={false}>{children}</Container>
             </Box>
         </Box>
     );

--- a/frontend/src/pages/Clientes.tsx
+++ b/frontend/src/pages/Clientes.tsx
@@ -27,6 +27,8 @@ import { useEffect, useState } from "react";
 import { jwtDecode } from "jwt-decode";
 import MenuItem from "@mui/material/MenuItem";
 
+const API = import.meta.env.VITE_API_URL;
+
 const formatarTelefone = (tel: string | null | undefined) => {
     if (!tel) return "";
     const numeros = tel.replace(/\D/g, "");
@@ -89,7 +91,7 @@ export default function Clientes() {
     const carregar = async () => {
         const params: any = {};
         if (repSelecionado) params.codusuario = repSelecionado;
-        const res = await axios.get("http://localhost:8501/clientes", {
+        const res = await axios.get(`${API}/clientes`, {
             params,
             headers: { Authorization: `Bearer ${token}` },
         });
@@ -103,7 +105,7 @@ export default function Clientes() {
 
     const carregarRepresentantes = async () => {
         const res = await axios.get(
-            "http://localhost:8501/usuarios/representantes",
+            `${API}/usuarios/representantes`,
             { headers: { Authorization: `Bearer ${token}` } }
         );
         setRepresentantes(res.data);
@@ -157,7 +159,7 @@ export default function Clientes() {
 
     const salvar = async (linha: LinhaCliente) => {
         await axios.put(
-            `http://localhost:8501/clientes/${linha.id_cliente}/grupos/${linha.id_grupo}`,
+            `${API}/clientes/${linha.id_cliente}/grupos/${linha.id_grupo}`,
             { potencial_compra: linha.potencial_compra },
             { headers: { Authorization: `Bearer ${token}` } }
         );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,8 @@
 import { Box, Paper, Typography, TextField, MenuItem } from "@mui/material";
 import { People, CalendarMonth, MonetizationOn } from "@mui/icons-material";
 import axios from "axios";
+
+const API = import.meta.env.VITE_API_URL;
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { jwtDecode } from "jwt-decode";
@@ -17,7 +19,7 @@ export default function Dashboard() {
     const carregar = async () => {
         const params: any = {};
         if (repSelecionado) params.codusuario = repSelecionado;
-        const resClientes = await axios.get("http://localhost:8501/clientes", {
+        const resClientes = await axios.get(`${API}/clientes`, {
             params,
             headers: { Authorization: `Bearer ${token}` },
         });
@@ -34,7 +36,7 @@ export default function Dashboard() {
         const fim = dayjs().endOf("week").format("YYYY-MM-DD");
         const paramsVisitas: any = { inicio, fim };
         if (repSelecionado) paramsVisitas.codusuario = repSelecionado;
-        const resVisitas = await axios.get("http://localhost:8501/visitas", {
+        const resVisitas = await axios.get(`${API}/visitas`, {
             params: paramsVisitas,
             headers: { Authorization: `Bearer ${token}` },
         });
@@ -43,7 +45,7 @@ export default function Dashboard() {
 
     const carregarRepresentantes = async () => {
         const res = await axios.get(
-            "http://localhost:8501/usuarios/representantes",
+            `${API}/usuarios/representantes`,
             { headers: { Authorization: `Bearer ${token}` } }
         );
         setRepresentantes(res.data);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
 
 export const api = axios.create({
-    baseURL: "http://localhost:8501",
+    baseURL: import.meta.env.VITE_API_URL,
 });


### PR DESCRIPTION
## Summary
- read API base URL from `.env`
- expand main layout to use full browser width
- update pages to use the new API helper
- add example `.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68525e73ecd0832486a64474f49c3567