### PR TITLE
Fix initial login redirect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,15 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { useContext } from "react";
 import Login from "./pages/Login";
 import Dashboard from "./pages/Dashboard";
 import Layout from "./components/Layout";
 import Agenda from "./pages/Agenda";
 import Clientes from "./pages/Clientes";
 import Sugestoes from "./pages/Sugestoes";
+import { AuthContext } from "./context/AuthContext";
 
 function App() {
-  const token = localStorage.getItem("token");
+  const { token } = useContext(AuthContext);
 
   return (
     <BrowserRouter>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -26,8 +26,9 @@ import {
     Link as LinkIcon,
 } from "@mui/icons-material"
 import { useNavigate, useLocation } from "react-router-dom"
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useContext } from "react"
 import { jwtDecode } from "jwt-decode"
+import { AuthContext } from "../context/AuthContext"
 
 // Interfaces
 interface Usuario {
@@ -107,12 +108,14 @@ const Sidebar = ({ onClose }: SidebarProps) => {
         }
     }, [isTokenValid])
 
+    const { setToken } = useContext(AuthContext)
+
     const handleLogout = useCallback(() => {
-        localStorage.removeItem("token")
+        setToken(null)
         localStorage.removeItem("usuario")
         setUsuario(null)
         navigate("/login", { replace: true })
-    }, [navigate])
+    }, [navigate, setToken])
 
     const handleNavigation = (rota: string) => {
         navigate(rota)

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useState, useEffect, ReactNode } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  setToken: (token: string | null) => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  token: null,
+  setToken: () => {}
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setTokenState] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token');
+    if (stored) setTokenState(stored);
+  }, []);
+
+  const setToken = (t: string | null) => {
+    if (t) {
+      localStorage.setItem('token', t);
+    } else {
+      localStorage.removeItem('token');
+    }
+    setTokenState(t);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./context/AuthContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,19 +1,21 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { Container, TextField, Button, Typography, Paper, Box } from "@mui/material";
 import { api } from "../services/api";
+import { AuthContext } from "../context/AuthContext";
 
 export default function Login() {
     const [login, setLogin] = useState("");
     const [senha, setSenha] = useState("");
     const [erro, setErro] = useState("");
     const navigate = useNavigate();
+    const { setToken } = useContext(AuthContext);
 
     const handleLogin = async () => {
         console.log("Tentando login com:", login, senha); // <- debug
         try {
             const response = await api.post("/auth/login", { login, senha });
-            localStorage.setItem("token", response.data.token);
+            setToken(response.data.token);
             navigate("/dashboard");
         } catch (err) {
             setErro("Usuário ou senha inválidos.");


### PR DESCRIPTION
## Summary
- implement AuthContext to track auth token
- wrap app with AuthProvider
- use AuthContext in App routing, Login and Sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685291aad29c83248548970eb18031db