### PR TITLE
Fix login for network access

### DIFF
--- a/frontend/src/hooks/useClientes.ts
+++ b/frontend/src/hooks/useClientes.ts
@@ -3,8 +3,7 @@
 import { useState, useEffect, useCallback } from "react"
 import axios from "axios"
 import { jwtDecode } from "jwt-decode"
-
-const API = import.meta.env.VITE_API_URL
+import { API_URL } from "../services/api"
 
 interface LinhaCliente {
     id_cliente: string
@@ -35,7 +34,7 @@ export const useClientes = () => {
             const params: any = {}
             if (repSelecionado) params.codusuario = repSelecionado
 
-            const res = await axios.get(`${API}/clientes`, {
+            const res = await axios.get(`${API_URL}/clientes`, {
                 params,
                 headers: { Authorization: `Bearer ${token}` },
             })
@@ -59,7 +58,7 @@ export const useClientes = () => {
         if (!token) return
 
         try {
-            const res = await axios.get(`${API}/usuarios/representantes`, {
+            const res = await axios.get(`${API_URL}/usuarios/representantes`, {
                 headers: { Authorization: `Bearer ${token}` },
             })
             setRepresentantes(res.data)
@@ -76,7 +75,7 @@ export const useClientes = () => {
 
             try {
                 const response = await axios.put(
-                    `${API}/clientes/${idCliente}/grupos/${idGrupo}`,
+                    `${API_URL}/clientes/${idCliente}/grupos/${idGrupo}`,
                     { potencial_compra: potencial },
                     {
                         headers: {

--- a/frontend/src/pages/Agenda.tsx
+++ b/frontend/src/pages/Agenda.tsx
@@ -23,8 +23,7 @@ import {
     TableRow,
 } from "@mui/material"
 import { Add, Check, CalendarMonth } from "@mui/icons-material"
-
-const API = import.meta.env.VITE_API_URL
+import { API_URL } from "../services/api"
 
 const horas = ["08:00", "09:00", "10:00", "11:00", "12:00", "13:00", "14:00", "15:00", "16:00", "17:00"]
 
@@ -69,7 +68,7 @@ const Agenda = () => {
         const fim = diasSemana[6].format("YYYY-MM-DD")
         const params: any = { inicio, fim }
         if (repSelecionado) params.codusuario = repSelecionado
-        const res = await axios.get(`${API}/visitas`, {
+        const res = await axios.get(`${API_URL}/visitas`, {
             params,
             headers: { Authorization: `Bearer ${token}` },
         })
@@ -79,7 +78,7 @@ const Agenda = () => {
     const buscarClientes = async () => {
         const params: any = {}
         if (repSelecionado) params.codusuario = repSelecionado
-        const res = await axios.get(`${API}/visitas/clientes/representante`, {
+        const res = await axios.get(`${API_URL}/visitas/clientes/representante`, {
             params,
             headers: { Authorization: `Bearer ${token}` },
         })
@@ -87,7 +86,7 @@ const Agenda = () => {
     }
 
     const carregarRepresentantes = async () => {
-        const res = await axios.get(`${API}/usuarios/representantes`, {
+        const res = await axios.get(`${API_URL}/usuarios/representantes`, {
             headers: { Authorization: `Bearer ${token}` },
         })
         setRepresentantes(res.data)
@@ -100,7 +99,7 @@ const Agenda = () => {
     }
 
     const salvarVisita = async () => {
-        await axios.post(`${API}/visitas`, novaVisita, {
+        await axios.post(`${API_URL}/visitas`, novaVisita, {
             headers: { Authorization: `Bearer ${token}` },
         })
         setModalAberto(false)
@@ -115,14 +114,14 @@ const Agenda = () => {
     const confirmarVisita = async () => {
         if (!visitaParaConfirmar) return
         await axios.put(
-            `${API}/visitas/${visitaParaConfirmar.id}/observacao`,
+            `${API_URL}/visitas/${visitaParaConfirmar.id}/observacao`,
             { observacao: observacaoEditada },
             {
                 headers: { Authorization: `Bearer ${token}` },
             },
         )
         await axios.put(
-            `${API}/visitas/${visitaParaConfirmar.id}/confirmar`,
+            `${API_URL}/visitas/${visitaParaConfirmar.id}/confirmar`,
             {},
             {
                 headers: { Authorization: `Bearer ${token}` },

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -26,8 +26,7 @@ import axios from "axios"
 import dayjs from "dayjs"
 import { useEffect, useState } from "react"
 import { jwtDecode } from "jwt-decode"
-
-const API = import.meta.env.VITE_API_URL
+import { API_URL } from "../services/api"
 
 export default function Dashboard() {
     const [clientes, setClientes] = useState<any[]>([])
@@ -46,7 +45,7 @@ export default function Dashboard() {
             if (repSelecionado) params.codusuario = repSelecionado
 
             // Carregar clientes
-            const resClientes = await axios.get(`${API}/clientes`, {
+            const resClientes = await axios.get(`${API_URL}/clientes`, {
                 params,
                 headers: { Authorization: `Bearer ${token}` },
             })
@@ -62,7 +61,7 @@ export default function Dashboard() {
             const fim = dayjs().endOf("week").format("YYYY-MM-DD")
             const paramsVisitas: any = { inicio, fim }
             if (repSelecionado) paramsVisitas.codusuario = repSelecionado
-            const resVisitas = await axios.get(`${API}/visitas`, {
+            const resVisitas = await axios.get(`${API_URL}/visitas`, {
                 params: paramsVisitas,
                 headers: { Authorization: `Bearer ${token}` },
             })
@@ -75,7 +74,7 @@ export default function Dashboard() {
     }
 
     const carregarRepresentantes = async () => {
-        const res = await axios.get(`${API}/usuarios/representantes`, {
+        const res = await axios.get(`${API_URL}/usuarios/representantes`, {
             headers: { Authorization: `Bearer ${token}` },
         })
         setRepresentantes(res.data)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,5 +1,12 @@
 import axios from "axios";
 
+// Base URL for API requests
+const envUrl = import.meta.env.VITE_API_URL || "http://localhost:8501";
+export const API_URL = envUrl.replace(
+  "localhost",
+  window.location.hostname,
+);
+
 export const api = axios.create({
-    baseURL: import.meta.env.VITE_API_URL,
+  baseURL: API_URL,
 });


### PR DESCRIPTION
## Summary
- derive API URL from request hostname
- use API_URL constant across dashboard, agenda, and clients hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852a885ca3483248937a62a2802ecfc