### PR TITLE
Add basic Flutter mobile app

### DIFF
--- a/mobile/agendarep_app/lib/agenda_page.dart
+++ b/mobile/agendarep_app/lib/agenda_page.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'api_service.dart';
+
+class AgendaPage extends StatefulWidget {
+  const AgendaPage({super.key});
+
+  @override
+  State<AgendaPage> createState() => _AgendaPageState();
+}
+
+class _AgendaPageState extends State<AgendaPage> {
+  final ApiService api = ApiService();
+  List<dynamic> visitas = [];
+  bool loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _carregarVisitas();
+  }
+
+  Future<void> _carregarVisitas() async {
+    final res = await api.get('/visitas?inicio=2024-01-01&fim=2024-12-31');
+    if (res.statusCode == 200) {
+      setState(() {
+        visitas = jsonDecode(res.body);
+        loading = false;
+      });
+    } else {
+      setState(() {
+        loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Agenda')),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: visitas.length,
+              itemBuilder: (context, index) {
+                final v = visitas[index];
+                return ListTile(
+                  title: Text(v['nome_cliente'] ?? 'Sem nome'),
+                  subtitle: Text('${v['data']} - ${v['hora']}'),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/mobile/agendarep_app/lib/api_service.dart
+++ b/mobile/agendarep_app/lib/api_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class ApiService {
+  static const String baseUrl = 'http://10.0.2.2:8501';
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  Future<String?> getToken() async {
+    return await _storage.read(key: 'token');
+  }
+
+  Future<void> setToken(String token) async {
+    await _storage.write(key: 'token', value: token);
+  }
+
+  Future<http.Response> post(String path, Map<String, dynamic> data) async {
+    final response = await http.post(
+      Uri.parse('$baseUrl$path'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(data),
+    );
+    return response;
+  }
+
+  Future<http.Response> get(String path) async {
+    final token = await getToken();
+    final response = await http.get(
+      Uri.parse('$baseUrl$path'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    return response;
+  }
+}

--- a/mobile/agendarep_app/lib/login_page.dart
+++ b/mobile/agendarep_app/lib/login_page.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'api_service.dart';
+
+class LoginPage extends StatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final TextEditingController _loginController = TextEditingController();
+  final TextEditingController _senhaController = TextEditingController();
+  String? erro;
+  final ApiService api = ApiService();
+
+  Future<void> _fazerLogin() async {
+    final res = await api.post('/auth/login', {
+      'login': _loginController.text,
+      'senha': _senhaController.text,
+    });
+    if (res.statusCode == 200) {
+      final data = jsonDecode(res.body);
+      await api.setToken(data['token']);
+      if (context.mounted) {
+        Navigator.of(context).pushReplacementNamed('/agenda');
+      }
+    } else {
+      setState(() {
+        erro = 'Usuário ou senha inválidos';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('AgendaRep - Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _loginController,
+              decoration: const InputDecoration(labelText: 'Usuário'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _senhaController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Senha'),
+            ),
+            if (erro != null) ...[
+              const SizedBox(height: 12),
+              Text(erro!, style: const TextStyle(color: Colors.red)),
+            ],
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _fazerLogin,
+              child: const Text('Entrar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/agendarep_app/lib/main.dart
+++ b/mobile/agendarep_app/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'login_page.dart';
+import 'agenda_page.dart';
 
 void main() {
   runApp(const AgendaRepApp());
@@ -11,23 +13,11 @@ class AgendaRepApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'AgendaRep',
-      theme: ThemeData(
-        primarySwatch: Colors.deepPurple,
-      ),
-      home: const HomePage(),
-    );
-  }
-}
-
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text("Bem-vindo ao AgendaRep!"),
-      ),
+      theme: ThemeData(primarySwatch: Colors.deepPurple),
+      routes: {
+        '/': (context) => const LoginPage(),
+        '/agenda': (context) => const AgendaPage(),
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- create a simple Flutter app under `mobile/agendarep_app`
- include login page that talks to `/auth/login`
- add agenda page fetching `/visitas`
- wire pages in `main.dart`

## Testing
- `npm test` *(fails: no tests defined)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ba560ae48324b2cc7acd48d423da