### PR TITLE
Add settings screen for backend URL and modern login

### DIFF
--- a/mobile/agendarep_app/lib/api_service.dart
+++ b/mobile/agendarep_app/lib/api_service.dart
@@ -3,8 +3,16 @@ import 'package:http/http.dart' as http;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class ApiService {
-  static const String baseUrl = 'http://10.0.2.2:8501';
+  static const String _defaultBaseUrl = 'http://10.0.2.2:8501';
   final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  Future<String> getBaseUrl() async {
+    return await _storage.read(key: 'base_url') ?? _defaultBaseUrl;
+  }
+
+  Future<void> setBaseUrl(String url) async {
+    await _storage.write(key: 'base_url', value: url);
+  }
 
   Future<String?> getToken() async {
     return await _storage.read(key: 'token');
@@ -15,6 +23,7 @@ class ApiService {
   }
 
   Future<http.Response> post(String path, Map<String, dynamic> data) async {
+    final baseUrl = await getBaseUrl();
     final response = await http.post(
       Uri.parse('$baseUrl$path'),
       headers: {'Content-Type': 'application/json'},
@@ -24,6 +33,7 @@ class ApiService {
   }
 
   Future<http.Response> get(String path) async {
+    final baseUrl = await getBaseUrl();
     final token = await getToken();
     final response = await http.get(
       Uri.parse('$baseUrl$path'),

--- a/mobile/agendarep_app/lib/login_page.dart
+++ b/mobile/agendarep_app/lib/login_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'api_service.dart';
 
+
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
 
@@ -36,32 +37,56 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('AgendaRep - Login')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            TextField(
-              controller: _loginController,
-              decoration: const InputDecoration(labelText: 'Usuário'),
+      appBar: AppBar(
+        title: const Text('AgendaRep - Login'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.of(context).pushNamed('/settings');
+            },
+          )
+        ],
+      ),
+      body: Center(
+        child: SingleChildScrollView(
+          child: Card(
+            elevation: 4,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
             ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: _senhaController,
-              obscureText: true,
-              decoration: const InputDecoration(labelText: 'Senha'),
+            margin: const EdgeInsets.all(24),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: _loginController,
+                    decoration: const InputDecoration(labelText: 'Usuário'),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _senhaController,
+                    obscureText: true,
+                    decoration: const InputDecoration(labelText: 'Senha'),
+                  ),
+                  if (erro != null) ...[
+                    const SizedBox(height: 12),
+                    Text(erro!, style: const TextStyle(color: Colors.red)),
+                  ],
+                  const SizedBox(height: 20),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _fazerLogin,
+                      child: const Text('Entrar'),
+                    ),
+                  ),
+                ],
+              ),
             ),
-            if (erro != null) ...[
-              const SizedBox(height: 12),
-              Text(erro!, style: const TextStyle(color: Colors.red)),
-            ],
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _fazerLogin,
-              child: const Text('Entrar'),
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/agendarep_app/lib/main.dart
+++ b/mobile/agendarep_app/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'login_page.dart';
 import 'agenda_page.dart';
+import 'settings_page.dart';
 
 void main() {
   runApp(const AgendaRepApp());
@@ -17,6 +18,7 @@ class AgendaRepApp extends StatelessWidget {
       routes: {
         '/': (context) => const LoginPage(),
         '/agenda': (context) => const AgendaPage(),
+        '/settings': (context) => const SettingsPage(),
       },
     );
   }

--- a/mobile/agendarep_app/lib/settings_page.dart
+++ b/mobile/agendarep_app/lib/settings_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'api_service.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  final ApiService api = ApiService();
+  final TextEditingController _urlController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final url = await api.getBaseUrl();
+    setState(() {
+      _urlController.text = url;
+    });
+  }
+
+  Future<void> _save() async {
+    await api.setBaseUrl(_urlController.text);
+    if (mounted) {
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Configurações')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _urlController,
+              decoration: const InputDecoration(labelText: 'URL do backend'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Salvar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow configuring backend URL in a new SettingsPage
- update ApiService to store and read the URL
- modernize LoginPage UI and add settings icon
- register new route in main.dart

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532a67a6d88324af35759300ec766c