### PR TITLE
Fix network access in release build

### DIFF
--- a/mobile/agendarep_app/android/app/src/main/AndroidManifest.xml
+++ b/mobile/agendarep_app/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.agendarep_app">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:name="${applicationName}"
         android:label="Agenda Rep"


### PR DESCRIPTION
## Summary
- allow HTTP calls from release builds by declaring the `INTERNET` permission

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533bbfbcf48324a4bb9fe010b70d9d