### PR TITLE
Implement basic navigation for Flutter app

### DIFF
--- a/mobile/agendarep_app/lib/clientes_page.dart
+++ b/mobile/agendarep_app/lib/clientes_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ClientesPage extends StatelessWidget {
+  const ClientesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Clientes em desenvolvimento'),
+    );
+  }
+}

--- a/mobile/agendarep_app/lib/dashboard_page.dart
+++ b/mobile/agendarep_app/lib/dashboard_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Dashboard em desenvolvimento'),
+    );
+  }
+}

--- a/mobile/agendarep_app/lib/home_page.dart
+++ b/mobile/agendarep_app/lib/home_page.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'agenda_page.dart';
+import 'dashboard_page.dart';
+import 'clientes_page.dart';
+import 'sugestoes_page.dart';
+import 'settings_page.dart';
+import 'api_service.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _index = 0;
+  final ApiService api = ApiService();
+
+  final List<Widget> _pages = const [
+    DashboardPage(),
+    AgendaPage(),
+    ClientesPage(),
+    SugestoesPage(),
+  ];
+
+  void _logout() async {
+    await api.setToken('');
+    if (!mounted) return;
+    Navigator.of(context).pushReplacementNamed('/');
+  }
+
+  void _openSettings() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const SettingsPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AgendaRep'),
+      ),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            const DrawerHeader(
+              child: Text('Menu'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.dashboard),
+              title: const Text('Dashboard'),
+              selected: _index == 0,
+              onTap: () {
+                setState(() => _index = 0);
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.calendar_today),
+              title: const Text('Agenda'),
+              selected: _index == 1,
+              onTap: () {
+                setState(() => _index = 1);
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.people),
+              title: const Text('Clientes'),
+              selected: _index == 2,
+              onTap: () {
+                setState(() => _index = 2);
+                Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.lightbulb),
+              title: const Text('Sugestões'),
+              selected: _index == 3,
+              onTap: () {
+                setState(() => _index = 3);
+                Navigator.pop(context);
+              },
+            ),
+            const Divider(),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Configurações'),
+              onTap: () {
+                Navigator.pop(context);
+                _openSettings();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.exit_to_app),
+              title: const Text('Sair'),
+              onTap: () {
+                Navigator.pop(context);
+                _logout();
+              },
+            ),
+          ],
+        ),
+      ),
+      body: _pages[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.dashboard),
+            label: 'Dashboard',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today),
+            label: 'Agenda',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.people),
+            label: 'Clientes',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.lightbulb),
+            label: 'Sugestões',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/agendarep_app/lib/login_page.dart
+++ b/mobile/agendarep_app/lib/login_page.dart
@@ -47,7 +47,7 @@ class _LoginPageState extends State<LoginPage> {
         await api.removeSavedUser();
       }
       if (context.mounted) {
-        Navigator.of(context).pushReplacementNamed('/agenda');
+        Navigator.of(context).pushReplacementNamed('/home');
       }
     } else {
       setState(() {

--- a/mobile/agendarep_app/lib/main.dart
+++ b/mobile/agendarep_app/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'home_page.dart';
 import 'login_page.dart';
-import 'agenda_page.dart';
 import 'settings_page.dart';
 
 void main() {
@@ -17,7 +17,7 @@ class AgendaRepApp extends StatelessWidget {
       theme: ThemeData(primarySwatch: Colors.deepPurple),
       routes: {
         '/': (context) => const LoginPage(),
-        '/agenda': (context) => const AgendaPage(),
+        '/home': (context) => const HomePage(),
         '/settings': (context) => const SettingsPage(),
       },
     );

--- a/mobile/agendarep_app/lib/sugestoes_page.dart
+++ b/mobile/agendarep_app/lib/sugestoes_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class SugestoesPage extends StatelessWidget {
+  const SugestoesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Sugestões de visita em desenvolvimento'),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- update mobile routes to show a new HomePage after login
- add dashboard/clientes/sugestoes placeholder pages
- implement HomePage with drawer navigation, bottom bar and logout

## Testing
- `flutter test` *(fails: command not found)*
- `npm test --silent` *(fails to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853a7a6e5d08324b8efc76f7231b0ea