### PR TITLE
Fix Flutter widget test

### DIFF
--- a/mobile/agendarep_app/test/widget_test.dart
+++ b/mobile/agendarep_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:agendarep_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const AgendaRepApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- update test to use `AgendaRepApp` widget

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853b022d5608324a31a6fe98248f3d6