### PR TITLE
Fix mobile client loading

### DIFF
--- a/mobile/agendarep_app/lib/clientes_page.dart
+++ b/mobile/agendarep_app/lib/clientes_page.dart
@@ -55,11 +55,12 @@ class _ClientesPageState extends State<ClientesPage> {
       setState(() => loadingMore = true);
     }
 
-    final res = await api.get('/clientes?pagina=$page&limite=$limit');
+    // A API do backend retorna a lista completa de clientes sem paginacao.
+    // Ajustamos a leitura para funcionar com esse formato.
+    final res = await api.get('/clientes');
     if (res.statusCode == 200) {
-      final Map<String, dynamic> body = jsonDecode(res.body);
-      final data = body['dados'] as List<dynamic>;
-      final int total = body['total'] as int? ?? data.length;
+      final List<dynamic> data = jsonDecode(res.body);
+      final int total = data.length;
 
       for (final row in data) {
         final id = row['id_cliente'].toString();


### PR DESCRIPTION
## Summary
- adjust ClientesPage to parse backend response without pagination

## Testing
- `npm test` *(fails: Missing script)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853bd74ce3c8324855fc8e19dfb5815