### PR TITLE
Integrate mobile dashboard with backend

### DIFF
--- a/mobile/agendarep_app/lib/dashboard_page.dart
+++ b/mobile/agendarep_app/lib/dashboard_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:jwt_decode/jwt_decode.dart';
 
 import 'api_service.dart';
 
@@ -17,6 +18,9 @@ class _DashboardPageState extends State<DashboardPage> {
 
   List<dynamic> clientes = [];
   List<dynamic> visitas = [];
+  List<dynamic> representantes = [];
+  String repSelecionado = '';
+  String perfil = '';
   bool loading = true;
 
   @override
@@ -25,23 +29,45 @@ class _DashboardPageState extends State<DashboardPage> {
     _loadData();
   }
 
+  Future<void> _loadRepresentantes() async {
+    final res = await api.get('/usuarios/representantes');
+    if (res.statusCode == 200) {
+      representantes = jsonDecode(res.body);
+    }
+  }
+
   Future<void> _loadData() async {
     setState(() => loading = true);
 
     try {
-      final resClientes = await api.get('/clientes');
+      final token = await api.getToken();
+      if (token != null) {
+        final data = Jwt.parseJwt(token);
+        perfil = data['perfil'] ?? '';
+        if ((perfil == 'coordenador' || perfil == 'diretor') && representantes.isEmpty) {
+          await _loadRepresentantes();
+        }
+      }
+
+      final clienteQuery = repSelecionado.isNotEmpty ? '?codusuario=$repSelecionado' : '';
+      final resClientes = await api.get('/clientes$clienteQuery');
       if (resClientes.statusCode == 200) {
         clientes = jsonDecode(resClientes.body);
+      } else {
+        clientes = [];
       }
 
       final now = DateTime.now();
       final start = now.subtract(Duration(days: now.weekday - 1));
       final end = start.add(const Duration(days: 6));
       final df = DateFormat('yyyy-MM-dd');
-      final resVisitas = await api
-          .get('/visitas?inicio=${df.format(start)}&fim=${df.format(end)}');
+      final visitasQuery =
+          '?inicio=${df.format(start)}&fim=${df.format(end)}${repSelecionado.isNotEmpty ? '&codusuario=$repSelecionado' : ''}';
+      final resVisitas = await api.get('/visitas$visitasQuery');
       if (resVisitas.statusCode == 200) {
         visitas = jsonDecode(resVisitas.body);
+      } else {
+        visitas = [];
       }
     } finally {
       setState(() => loading = false);
@@ -56,6 +82,10 @@ class _DashboardPageState extends State<DashboardPage> {
       0,
       (sum, c) =>
           sum + ((c['potencial_compra'] as num?)?.toDouble() ?? 0.0));
+  double get totalComprado => clientes.fold(
+      0,
+      (sum, c) => sum + ((c['valor_comprado'] as num?)?.toDouble() ?? 0.0));
+  int get qtdClientes => clientes.map((c) => c['id_cliente']).toSet().length;
 
   @override
   Widget build(BuildContext context) {
@@ -68,23 +98,48 @@ class _DashboardPageState extends State<DashboardPage> {
       child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          if (perfil == 'coordenador' || perfil == 'diretor')
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: DropdownButtonFormField<String>(
+                value: repSelecionado.isEmpty ? null : repSelecionado,
+                decoration: const InputDecoration(labelText: 'Representante'),
+                items: [
+                  const DropdownMenuItem(value: '', child: Text('Todos')),
+                  ...representantes.map((r) => DropdownMenuItem(
+                        value: r['codusuario'].toString(),
+                        child: Text(r['nome']),
+                      ))
+                ],
+                onChanged: (v) {
+                  setState(() => repSelecionado = v ?? '');
+                  _loadData();
+                },
+              ),
+            ),
           Row(
             children: [
-              _buildCard('Clientes', clientes.length.toString(), Icons.people),
+              _buildCard('Clientes', qtdClientes.toString(), Icons.people),
               _buildCard(
-                  'Visitas', visitas.length.toString(), Icons.calendar_today),
+                  'Potencial',
+                  NumberFormat.simpleCurrency(locale: 'pt_BR')
+                      .format(potencialTotal),
+                  Icons.monetization_on),
+              _buildCard(
+                  'Comprado',
+                  NumberFormat.simpleCurrency(locale: 'pt_BR')
+                      .format(totalComprado),
+                  Icons.trending_up),
             ],
           ),
           const SizedBox(height: 16),
           Row(
             children: [
               _buildCard(
-                  'Potencial',
-                  NumberFormat.simpleCurrency(locale: 'pt_BR')
-                      .format(potencialTotal),
-                  Icons.monetization_on),
+                  'Visitas', visitas.length.toString(), Icons.calendar_today),
               _buildCard('Confirmadas', visitasConfirmadas.toString(),
                   Icons.check_circle),
+              _buildStatusCard(),
             ],
           ),
           const SizedBox(height: 24),
@@ -116,6 +171,35 @@ class _DashboardPageState extends State<DashboardPage> {
               ),
               const SizedBox(height: 4),
               Text(label),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusCard() {
+    return Expanded(
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            children: [
+              const Text('Status', style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                children: [
+                  Chip(
+                    label: Text('$visitasConfirmadas Confirmadas'),
+                    backgroundColor: Colors.green.shade50,
+                  ),
+                  Chip(
+                    label: Text('$visitasPendentes Pendentes'),
+                    backgroundColor: Colors.orange.shade50,
+                  ),
+                ],
+              )
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- decode JWT token in Flutter dashboard
- load representatives list when allowed
- load clients and visits with selected representative filter
- display potential, purchased totals and status
- add dropdown filter and status chips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854447283688324a3789b4b83f4ef8d