### PR TITLE
Fix clientes page number parsing

### DIFF
--- a/mobile/agendarep_app/lib/clientes_page.dart
+++ b/mobile/agendarep_app/lib/clientes_page.dart
@@ -78,8 +78,10 @@ class _ClientesPageState extends State<ClientesPage> {
         final grupo = {
           'id_grupo': row['id_grupo'],
           'nome_grupo': row['nome_grupo'],
-          'potencial_compra': (row['potencial_compra'] as num?)?.toDouble() ?? 0,
-          'valor_comprado': (row['valor_comprado'] as num?)?.toDouble() ?? 0,
+          'potencial_compra':
+              double.tryParse(row['potencial_compra'].toString()) ?? 0.0,
+          'valor_comprado':
+              double.tryParse(row['valor_comprado'].toString()) ?? 0.0,
         };
         clientesMap[id]!['grupos'].add(grupo);
         clientesMap[id]!['totalPotencial'] += grupo['potencial_compra'];


### PR DESCRIPTION
## Summary
- fix clientes list parsing by using `double.tryParse`

## Testing
- `bash -lc 'flutter --version'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546e9db13c8324bd1d4c63b110df1a