### PR TITLE
Padroniza cabeçalho e navegação mobile

### DIFF
--- a/mobile/agendarep_app/lib/agenda_page.dart
+++ b/mobile/agendarep_app/lib/agenda_page.dart
@@ -123,47 +123,85 @@ class _AgendaPageState extends State<AgendaPage> {
 
   @override
   Widget build(BuildContext context) {
+    if (loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
-      appBar: AppBar(title: const Text('AgendaRep')),
-      body: loading
-          ? const Center(child: CircularProgressIndicator())
-          : RefreshIndicator(
-              onRefresh: _carregarDados,
-              child: ListView(
-                padding: const EdgeInsets.all(16),
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: RefreshIndicator(
+          onRefresh: _carregarDados,
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Row(
                 children: [
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      IconButton(
-                        onPressed: _semanaAnterior,
-                        icon: const Icon(Icons.chevron_left),
-                      ),
-                      Text(
-                        _tituloSemana(),
-                        style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                      IconButton(
-                        onPressed: _proximaSemana,
-                        icon: const Icon(Icons.chevron_right),
+                  const Text('AgendaRep',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 20,
+                        color: Colors.indigo,
+                      )),
+                  const Spacer(),
+                  PopupMenuButton<String>(
+                    icon: const CircleAvatar(
+                      radius: 18,
+                      backgroundColor: Colors.deepPurple,
+                      child: Text('V', style: TextStyle(color: Colors.white)),
+                    ),
+                    onSelected: (value) async {
+                      if (value == 'logout') {
+                        await api.setToken('');
+                        if (!mounted) return;
+                        Navigator.pushReplacementNamed(context, '/');
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem<String>(
+                        value: 'logout',
+                        child: Text('Sair'),
                       ),
                     ],
                   ),
-                  const SizedBox(height: 8),
-                  SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Table(
-                      defaultColumnWidth: const IntrinsicColumnWidth(),
-                      border: TableBorder.all(color: Colors.grey.shade300),
-                      children: [
-                        _buildHeaderRow(),
-                        ...horas.map(_buildLinhaHora),
-                      ],
-                    ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  IconButton(
+                    onPressed: _semanaAnterior,
+                    icon: const Icon(Icons.chevron_left),
+                  ),
+                  Text(
+                    _tituloSemana(),
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  IconButton(
+                    onPressed: _proximaSemana,
+                    icon: const Icon(Icons.chevron_right),
                   ),
                 ],
               ),
-            ),
+              const SizedBox(height: 8),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Table(
+                  defaultColumnWidth: const IntrinsicColumnWidth(),
+                  border: TableBorder.all(color: Colors.grey.shade300),
+                  children: [
+                    _buildHeaderRow(),
+                    ...horas.map(_buildLinhaHora),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/mobile/agendarep_app/lib/clientes_page.dart
+++ b/mobile/agendarep_app/lib/clientes_page.dart
@@ -245,52 +245,91 @@ class _ClientesPageState extends State<ClientesPage> {
   @override
   Widget build(BuildContext context) {
     if (loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
     }
 
-    return RefreshIndicator(
-      onRefresh: () => _loadClientes(reset: true),
-      child: ListView(
-        controller: _scrollController,
-        padding: const EdgeInsets.all(16),
-        children: [
-          TextField(
-            controller: _searchController,
-            decoration: const InputDecoration(
-              labelText: 'Buscar cliente',
-              prefixIcon: Icon(Icons.search),
-            ),
-            onChanged: (_) => setState(() {}),
-          ),
-          const SizedBox(height: 16),
-          ..._filteredClientes.map((c) => Card(
-                child: ListTile(
-                  title: Text(c['nome']),
-                  subtitle: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (c['telefone'] != null)
-                        Text(c['telefone'],
-                            style: const TextStyle(fontSize: 12)),
-                      Text(
-                          'Potencial: ${_formatCurrency(c['totalPotencial'])}'),
-                      Text('Comprado: ${_formatCurrency(c['totalComprado'])}'),
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: RefreshIndicator(
+          onRefresh: () => _loadClientes(reset: true),
+          child: ListView(
+            controller: _scrollController,
+            padding: const EdgeInsets.all(16),
+            children: [
+              Row(
+                children: [
+                  const Text('AgendaRep',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 20,
+                        color: Colors.indigo,
+                      )),
+                  const Spacer(),
+                  PopupMenuButton<String>(
+                    icon: const CircleAvatar(
+                      radius: 18,
+                      backgroundColor: Colors.deepPurple,
+                      child: Text('V', style: TextStyle(color: Colors.white)),
+                    ),
+                    onSelected: (value) async {
+                      if (value == 'logout') {
+                        await api.setToken('');
+                        if (!mounted) return;
+                        Navigator.pushReplacementNamed(context, '/');
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem<String>(
+                        value: 'logout',
+                        child: Text('Sair'),
+                      ),
                     ],
                   ),
-                  trailing: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text('${c['progresso']}%'),
-                    ],
-                  ),
-                  onTap: () => _openDetalhes(c),
+                ],
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _searchController,
+                decoration: const InputDecoration(
+                  labelText: 'Buscar cliente',
+                  prefixIcon: Icon(Icons.search),
                 ),
-              )),
-          if (loadingMore) ...[
-            const SizedBox(height: 16),
-            const Center(child: CircularProgressIndicator()),
-          ]
-        ],
+                onChanged: (_) => setState(() {}),
+              ),
+              const SizedBox(height: 16),
+              ..._filteredClientes.map((c) => Card(
+                    child: ListTile(
+                      title: Text(c['nome']),
+                      subtitle: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (c['telefone'] != null)
+                            Text(c['telefone'],
+                                style: const TextStyle(fontSize: 12)),
+                          Text(
+                              'Potencial: ${_formatCurrency(c['totalPotencial'])}'),
+                          Text('Comprado: ${_formatCurrency(c['totalComprado'])}'),
+                        ],
+                      ),
+                      trailing: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text('${c['progresso']}%'),
+                        ],
+                      ),
+                      onTap: () => _openDetalhes(c),
+                    ),
+                  )),
+              if (loadingMore) ...[
+                const SizedBox(height: 16),
+                const Center(child: CircularProgressIndicator()),
+              ]
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/mobile/agendarep_app/lib/home_page.dart
+++ b/mobile/agendarep_app/lib/home_page.dart
@@ -39,75 +39,13 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('AgendaRep'),
-      ),
-      drawer: Drawer(
-        child: ListView(
-          children: [
-            const DrawerHeader(
-              child: Text('Menu'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.dashboard),
-              title: const Text('Dashboard'),
-              selected: _index == 0,
-              onTap: () {
-                setState(() => _index = 0);
-                Navigator.pop(context);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.calendar_today),
-              title: const Text('Agenda'),
-              selected: _index == 1,
-              onTap: () {
-                setState(() => _index = 1);
-                Navigator.pop(context);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.people),
-              title: const Text('Clientes'),
-              selected: _index == 2,
-              onTap: () {
-                setState(() => _index = 2);
-                Navigator.pop(context);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.lightbulb),
-              title: const Text('Sugestões'),
-              selected: _index == 3,
-              onTap: () {
-                setState(() => _index = 3);
-                Navigator.pop(context);
-              },
-            ),
-            const Divider(),
-            ListTile(
-              leading: const Icon(Icons.settings),
-              title: const Text('Configurações'),
-              onTap: () {
-                Navigator.pop(context);
-                _openSettings();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.exit_to_app),
-              title: const Text('Sair'),
-              onTap: () {
-                Navigator.pop(context);
-                _logout();
-              },
-            ),
-          ],
-        ),
-      ),
       body: _pages[_index],
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _index,
         onTap: (i) => setState(() => _index = i),
+        backgroundColor: Colors.white,
+        selectedItemColor: Colors.deepPurple,
+        unselectedItemColor: Colors.grey,
         items: const [
           BottomNavigationBarItem(
             icon: Icon(Icons.dashboard),


### PR DESCRIPTION
## Summary
- remove menu lateral e appbar do HomePage
- adiciona cor nos ícones do menu inferior
- insere cabeçalho com nome do app e avatar em Agenda e Clientes

## Testing
- `flutter analyze` *(fails: command not found)*
- `npm run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6857046325e88324b8be61f45ca623fb