### PR TITLE
Fix dashboard API URL selection

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -19,8 +19,7 @@ import axios from "axios"
 import dayjs from "dayjs"
 import { useEffect, useState } from "react"
 import { jwtDecode } from "jwt-decode"
-
-const API = import.meta.env.VITE_API_URL
+import { API_URL } from "../services/api"
 
 export default function Dashboard() {
     const [clientes, setClientes] = useState<any[]>([])
@@ -40,7 +39,7 @@ export default function Dashboard() {
             if (repSelecionado) params.codusuario = repSelecionado
 
             // Carregar clientes
-            const resClientes = await axios.get(`${API}/clientes`, {
+            const resClientes = await axios.get(`${API_URL}/clientes`, {
                 params,
                 headers: { Authorization: `Bearer ${token}` },
             })
@@ -58,7 +57,7 @@ export default function Dashboard() {
             const fim = dayjs().endOf("week").format("YYYY-MM-DD")
             const paramsVisitas: any = { inicio, fim }
             if (repSelecionado) paramsVisitas.codusuario = repSelecionado
-            const resVisitas = await axios.get(`${API}/visitas`, {
+            const resVisitas = await axios.get(`${API_URL}/visitas`, {
                 params: paramsVisitas,
                 headers: { Authorization: `Bearer ${token}` },
             })
@@ -71,7 +70,7 @@ export default function Dashboard() {
     }
 
     const carregarRepresentantes = async () => {
-        const res = await axios.get(`${API}/usuarios/representantes`, {
+        const res = await axios.get(`${API_URL}/usuarios/representantes`, {
             headers: { Authorization: `Bearer ${token}` },
         })
         setRepresentantes(res.data)


### PR DESCRIPTION
## Summary
- import dynamic API_URL constant in Dashboard
- call API using this dynamic URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6857ed30e9108324b17dd39d849e5331